### PR TITLE
feat: extract direct video URL from tiktok video data

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -49,12 +49,12 @@ generate.get('/video/:videoId', async (c) => {
       })
     }
 
-    const highAvailable = data.video.bitrateInfo.find((bitrate) => bitrate.CodecType.includes('h265'))
+    const highQualityVideo = data.video.bitrateInfo.find((bitrate) => bitrate.CodecType.includes('h265'))
 
-    if (hq && highAvailable) {
-      return c.redirect(`https://tikwm.com/video/media/hdplay/${videoId}.mp4`)
+    if (hq && highQualityVideo) {
+      return c.redirect(highQualityVideo.PlayAddr.UrlList.find(url => new URL(url).pathname === '/aweme/v1/play/'))
     } else {
-      return c.redirect(`https://tikwm.com/video/media/play/${videoId}.mp4`)
+      return c.redirect(data.video.PlayAddrStruct.UrlList.find(url => new URL(url).pathname === '/aweme/v1/play/'))
     }
   } catch (e) {
     return new Response((e as Error).message, {

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -37,7 +37,7 @@ generate.get('/video/:videoId', async (c) => {
   const hq = c.req.query('hq') === 'true' || c.req.query('quality') === 'hq'
 
   try {
-    // To ensure the video is valid, decrease load on TikWM by checking the video data first
+    // Ensure the video is valid
     const data = await scrapeVideoData(videoId)
 
     if (data instanceof Error) {
@@ -49,13 +49,18 @@ generate.get('/video/:videoId', async (c) => {
       })
     }
 
-    const highQualityVideo = data.video.bitrateInfo.find((bitrate) => bitrate.CodecType.includes('h265'))
+    const h265Video = data.video.bitrateInfo.find((b) => b.CodecType.includes('h265'))
+    const h265VideoPlayUrl = h265Video?.PlayAddr?.UrlList?.find((u: string) => u.includes('/aweme/v1/play/'))
 
-    if (hq && highQualityVideo) {
-      return c.redirect(highQualityVideo.PlayAddr.UrlList.find(url => new URL(url).pathname === '/aweme/v1/play/'))
+    const videoPlayUrl = data.video?.PlayAddrStruct?.UrlList?.find((u: string) => u.includes('/aweme/v1/play/'))
+
+    if (hq && h265VideoPlayUrl) {
+      return c.redirect(h265VideoPlayUrl)
+    } else if (videoPlayUrl) {
+      return c.redirect(videoPlayUrl)
     } else {
-      return c.redirect(data.video.PlayAddrStruct.UrlList.find(url => new URL(url).pathname === '/aweme/v1/play/'))
-    }
+      throw new Error('Could not find an aweme play URL')
+	}
   } catch (e) {
     return new Response((e as Error).message, {
       status: 500,

--- a/src/types/Web.ts
+++ b/src/types/Web.ts
@@ -2931,6 +2931,7 @@ export interface Video {
   zoomCover: ZoomCover
   volumeInfo: VolumeInfo
   bitrateInfo: BitrateInfo[]
+  PlayAddrStruct: PlayAddr
   VQScore: string
 }
 


### PR DESCRIPTION
TikWM's hdplay API no longer works; getting the high-quality HEVC video from TikTok's video data is more reliable and functional. The H.264 non-HD stream will continue to work. This should also fix #36 