### PR TITLE
fix: shortlink tiktoks not embedding

### DIFF
--- a/src/services/tiktok.ts
+++ b/src/services/tiktok.ts
@@ -88,9 +88,6 @@ export async function grabAwemeId(videoId: string): Promise<URL> {
   }
 
   const res = await fetch('https://vm.tiktok.com/' + videoId, {
-    headers: {
-      'User-Agent': 'Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)'
-    },
     cf: {
       cacheEverything: false,
       cacheTtlByStatus: { '301-302': 86400, 404: 1, '500-599': 0 }


### PR DESCRIPTION
Some TikTok shortlinks have stopped working recently
Example: https://vt.tnktok.com/ZSV6dxELD/ returns 500 Internal Server Error

Seems like TikTok has stopped returning the "Location" in its response headers when the User-Agent is the Discordbot UA. Using any other User-Agent still returns the Location header.

This removes the Discordbot User-Agent that was used to resolve vt.tiktok.com and vm.tiktok.com shortlinks.